### PR TITLE
Handle css class for copied state

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,7 @@
         <div
           data-controller="clipboard"
           data-clipboard-success-content="Copied!"
+          data-clipboard-copied-class="text-yellow-600"
           class="mt-1 flex rounded-md shadow-sm"
         >
           <input

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,21 @@ import { Controller } from 'stimulus'
 
 export default class extends Controller {
   hasButtonTarget: boolean
+  hasCopiedClass: boolean
   originalText: string
   successDuration: number
   successDurationValue: number
   timeout: number
   buttonTarget: HTMLElement
   sourceTarget: HTMLInputElement
+  copiedClass: string
 
   static targets = ['button', 'source']
   static values = {
     successDuration: Number
   }
+
+  static classes = ['copied']
 
   connect (): void {
     if (!this.hasButtonTarget) return
@@ -38,9 +42,15 @@ export default class extends Controller {
     }
 
     this.buttonTarget.innerText = this.data.get('successContent')
+    if (this.hasCopiedClass) {
+      this.buttonTarget.classList.add(this.copiedClass)
+    }
 
     this.timeout = setTimeout(() => {
       this.buttonTarget.innerText = this.originalText
+      if (this.hasCopiedClass) {
+        this.buttonTarget.classList.remove(this.copiedClass)
+      }
     }, this.successDuration)
   }
 }


### PR DESCRIPTION
In addition to changing the target button's text, the Stimulus class `copied` can be used to give a visual feedback when copying to the clipboard.

If defined, the `copied` class is added when the content is copied, and removed when the initial text is restored.