### PR TITLE
Prefer Clipboard API over execCommand

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,7 @@ export default class extends Controller {
   copy (event: Event): void {
     event.preventDefault()
 
-    this.sourceTarget.select()
-    document.execCommand('copy')
-
-    this.copied()
+    navigator.clipboard.writeText(this.sourceText()).then(() => this.copied())
   }
 
   copied (): void {
@@ -43,5 +40,9 @@ export default class extends Controller {
     this.timeout = setTimeout(() => {
       this.buttonTarget.innerText = this.originalText
     }, this.successDurationValue)
+  }
+
+  sourceText (): string {
+    return this.sourceTarget.value
   }
 }


### PR DESCRIPTION
`Document.execCommand` [is deprecated](http://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) and could be removed in the future. [Clipboard API](http://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) is the replacement to use going forward.

The Clipboard API nets us some improvements over execCommand, namely that we no longer have to select the text to copy first. This means we can get rid of the visible input field if we so desire.

It does however also mean we have to abandon Internet Explorer, which [seems acceptable](https://github.com/stimulus-components/stimulus-clipboard/issues/1#issuecomment-1145259393).

References #1 and #5 