### PR TITLE
Use innerHTML for originalContent, so icons can be used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   hasButtonTarget: boolean
-  originalText: string
+  originalContent: string
   successDurationValue: number
   timeout: number
   buttonTarget: HTMLElement
@@ -19,7 +19,7 @@ export default class extends Controller {
   connect (): void {
     if (!this.hasButtonTarget) return
 
-    this.originalText = this.buttonTarget.innerText
+    this.originalContent = this.buttonTarget.innerHTML
   }
 
   copy (event: Event): void {
@@ -38,7 +38,7 @@ export default class extends Controller {
     this.buttonTarget.innerText = this.data.get('successContent')
 
     this.timeout = setTimeout(() => {
-      this.buttonTarget.innerText = this.originalText
+      this.buttonTarget.innerHTML = this.originalContent
     }, this.successDurationValue)
   }
 }


### PR DESCRIPTION
This fixes #7 and makes it possible, to use buttons with icon only.

I was unsure, if we should change it for the successContent as well. What do you think?