### PR TITLE
Use innerText, if the target is not an input-field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@ export default class extends Controller {
   copy (event: Event): void {
     event.preventDefault()
 
-    navigator.clipboard.writeText(this.sourceTarget.value).then(() => this.copied())
+    if("input" == this.sourceTarget.tagName) {
+      navigator.clipboard.writeText(this.sourceTarget.value).then(() => this.copied())
+    } else {
+      navigator.clipboard.writeText(this.sourceTarget.innerText).then(() => this.copied())
+    }
   }
 
   copied (): void {


### PR DESCRIPTION
So this can be used for other HTML-Elements as well (e.g. pre, code, div, e.g.)