### PR TITLE
Allow to use HTML for success content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow to use HTML for success content.
+
 ## [3.3.0] - 2022-12-23
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
       <section class="mt-16">
         <div
           data-controller="clipboard"
-          data-clipboard-success-content="Copied!"
+          data-clipboard-success-content="<strong>Copied!</strong>"
           class="mt-1 flex rounded-md shadow-sm"
         >
           <input
@@ -172,7 +172,7 @@
           </button>
         </div>
 
-        <div data-controller="clipboard" data-clipboard-success-content="Copied!" class="relative mt-16">
+        <div data-controller="clipboard" data-clipboard-success-content="<strong>Copied!</strong>" class="relative mt-16">
           <button
             class="absolute top-2 right-2 p-2 bg-white hover:bg-gray-200 rounded"
             type="button"

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export default class extends Controller {
       clearTimeout(this.timeout)
     }
 
-    this.buttonTarget.innerText = this.data.get('successContent')
+    this.buttonTarget.innerHTML = this.data.get('successContent')
 
     this.timeout = setTimeout(() => {
       this.buttonTarget.innerHTML = this.originalContent


### PR DESCRIPTION
Hi,

I was trying to use a custom icon for the success content, however it didn't work, so here is the PR :) 

Just found the repository for the docs! :smile: I'll send a PR for the docs once both PRs are merged/closed.

Cheers!